### PR TITLE
Testing GitHub workflow

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-    # username => aagarwal1996
-
 setuptools.setup(
     name="synthetic_combinations",
     version="0.0.2",
@@ -53,5 +51,5 @@ setuptools.setup(
         "urllib3==1.26.15",
         "xarray==2023.3.0"
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.9',
 )


### PR DESCRIPTION
# Description
- Update python version requirement to be greater than or equal to 3.9
- Change the `setup.py` file to enforce the version requirement
- Update the github workflow `python-package.yaml` to no longer test version 3.8